### PR TITLE
fix: redux error when server side rendering

### DIFF
--- a/src/pages/FriendPage.tsx
+++ b/src/pages/FriendPage.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable jsx-a11y/alt-text */
 /* eslint-disable @next/next/no-img-element */
+import dynamic from 'next/dynamic';
 import React, { useState, useEffect, useCallback } from 'react';
 
 // Components
@@ -18,7 +19,7 @@ import { useSelector } from 'react-redux';
 // Services
 import { apiService } from '@/services/api.service';
 
-const FriendPage: React.FC = React.memo(() => {
+const FriendPageComponent: React.FC = React.memo(() => {
   // Redux
   const user = useSelector((state: { user: User }) => state.user);
   const sessionId = useSelector(
@@ -141,6 +142,11 @@ const FriendPage: React.FC = React.memo(() => {
   );
 });
 
-FriendPage.displayName = 'FriendPage';
+FriendPageComponent.displayName = 'FriendPageComponent';
+
+// use dynamic import to disable SSR
+const FriendPage = dynamic(() => Promise.resolve(FriendPageComponent), {
+  ssr: false,
+});
 
 export default FriendPage;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-'use client';
+import dynamic from 'next/dynamic';
 
 import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -33,7 +33,7 @@ import { clearUser, setUser } from '@/redux/userSlice';
 import { clearSessionToken, setSessionToken } from '@/redux/sessionTokenSlice';
 import UserStatusDisplay from '@/components/UserStatusDispIay';
 
-const Home = () => {
+const HomeComponent = () => {
   // Socket Control
   const socket = useSocket();
 
@@ -214,6 +214,11 @@ const Home = () => {
     </div>
   );
 };
-Home.displayName = 'Home';
+HomeComponent.displayName = 'HomeComponent';
+
+// use dynamic import to disable SSR
+const Home = dynamic(() => Promise.resolve(HomeComponent), {
+  ssr: false,
+});
 
 export default Home;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
+import dynamic from 'next/dynamic';
 import React, { useState, useEffect } from 'react';
 import { Search } from 'lucide-react';
 
@@ -36,10 +37,11 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server }) => {
   );
 
   // Socket Control
-  const sokcet = useSocket();
+  const socket = useSocket();
 
   const handleServerSelect = (serverId: string) => {
-    sokcet?.emit('connectServer', { serverId, sessionId });
+    if (typeof window === 'undefined') return;
+    socket?.emit('connectServer', { serverId, sessionId });
     errorHandler.handle = () => {
       console.log('error');
     };
@@ -134,7 +136,7 @@ const Header: React.FC<HeaderProps> = React.memo(({ onSearch }) => {
 Header.displayName = 'Header';
 
 // HomePage Component
-const HomePage: React.FC = React.memo(() => {
+const HomePageComponent: React.FC = React.memo(() => {
   // Redux
   const sessionId = useSelector(
     (state: { sessionToken: string }) => state.sessionToken,
@@ -145,6 +147,7 @@ const HomePage: React.FC = React.memo(() => {
   const [joinedServers, setJoinedServers] = useState<Server[]>([]);
 
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     if (!sessionId) return;
 
     const fetchServerDatas = async () => {
@@ -222,6 +225,11 @@ const HomePage: React.FC = React.memo(() => {
   );
 });
 
-HomePage.displayName = 'HomePage';
+HomePageComponent.displayName = 'HomePageComponent';
+
+// use dynamic import to disable SSR
+const HomePage = dynamic(() => Promise.resolve(HomePageComponent), {
+  ssr: false,
+});
 
 export default HomePage;

--- a/src/pages/ServerPage.tsx
+++ b/src/pages/ServerPage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @next/next/no-img-element */
+import dynamic from 'next/dynamic';
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -42,7 +43,7 @@ const getStoredBoolean = (key: string, defaultValue: boolean): boolean => {
   return stored === 'true';
 };
 
-const ServerPage: React.FC = () => {
+const ServerPageComponent: React.FC = () => {
   // Redux
   const user = useSelector((state: { user: User }) => state.user);
   const server = useSelector((state: { server: Server }) => state.server);
@@ -354,6 +355,11 @@ const ServerPage: React.FC = () => {
   );
 };
 
-ServerPage.displayName = 'ServerPage';
+ServerPageComponent.displayName = 'ServerPageComponent';
+
+// use dynamic import to disable SSR
+const ServerPage = dynamic(() => Promise.resolve(ServerPageComponent), {
+  ssr: false,
+});
 
 export default ServerPage;


### PR DESCRIPTION
The error occurred because Redux was not available during server-side rendering.
This PR fixed the issue by ensuring that components dependent on Redux are only rendered on the client side, thereby avoiding the error during SSR.